### PR TITLE
feat: prod deployment uses entrust SSL cert

### DIFF
--- a/helm/cas-metabase/values-prod.yaml
+++ b/helm/cas-metabase/values-prod.yaml
@@ -25,11 +25,8 @@ route:
 metabase:
   nginxSidecar:
     enable: true
-    # set to false to deploy the application with an insecure route,
-    # and issue an SSL certificate using acme.sh
-    # sslTermination: false
     # Use Entrust ACME server. This secret is created by cas-pipeline
-    # caServerSecret: cas-acme-url
-    # caServerKey: url
+    caServerSecret: cas-acme-url
+    caServerKey: url
     caAccountEmail: matthieu@button.is # Todo: update to ggircs@gov.bc.ca when provisioned
     hostName: cas-metabase.nrs.gov.bc.ca


### PR DESCRIPTION
This was manually deployed. 
SSL cert at https://cas-metabase.nrs.gov.bc.ca/ now uses Entrust CA