### PR TITLE
refactor: handle non-json query return & append error to output

### DIFF
--- a/broken_questions/broken_questions.go
+++ b/broken_questions/broken_questions.go
@@ -122,8 +122,10 @@ func questionIsBroken(url string, session_id string, id int, client http.Client)
 
 	// Send http request
 	res, err := client.Do(req)
+	log.Println(res)
 	if err != nil {
-		log.Fatalln(err)
+		// Return broken=true if query fails (ie: timeout)
+		return true
 	}
 
 	// Do not close response until the function is done


### PR DESCRIPTION
A POST to /api/card/:id/query does not return json if it times out.
Added a jq -e check before parsing to handle the return of a timeout question.
Appended the error details to the output of broken_questions.sh. Now outputs (id, creator, updated_at, error)