### PR TITLE
chore: fix issue of parsing k8s template without sidecar enabled

### DIFF
--- a/helm/metabase/templates/deployment.yaml
+++ b/helm/metabase/templates/deployment.yaml
@@ -25,8 +25,8 @@ spec:
     spec:
       imagePullSecrets:
         - name: dockerhub-registry
-{{- if .Values.nginxSidecar.enable }}
       containers:
+{{- if .Values.nginxSidecar.enable }}
         - name: {{ .Chart.Name }}-nginx
           image: "{{ .Values.nginxSidecar.image.repository }}:{{ .Values.nginxSidecar.image.tag }}"
           imagePullPolicy: {{ .Values.nginxSidecar.image.pullPolicy }}


### PR DESCRIPTION
We want to move the condition to inside `spec > template > spec > containers` so that the k8s template generated by Helm is still valid.