### PR TITLE
chore: remove subresource from scaleTargetRef object

### DIFF
--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cas-metabase
 description: A Helm chart for the CAS Metabase instance
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: 0.40.0
 dependencies:
   - name: cas-postgres

--- a/helm/cas-metabase/templates/autoscaler.yaml
+++ b/helm/cas-metabase/templates/autoscaler.yaml
@@ -8,7 +8,6 @@ spec:
     kind: Deployment
     name: {{ template "cas-metabase.fullname" . }}
     apiVersion: apps/v1
-    subresource: scale
   minReplicas: {{ .Values.metabaseHPA.minReplicas }}
   maxReplicas: {{ .Values.metabaseHPA.maxReplicas }}
   targetCPUUtilizationPercentage: 80


### PR DESCRIPTION
Looks like subresource was an OCP3 thing