### PR TITLE
Chore: prod-test restore dag dependency

### DIFF
--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -15,3 +15,7 @@ dependencies:
     version: 1.0.7
     repository: https://bcgov.github.io/cas-airflow
     alias: download-cas-metabase-dags
+  - name: cas-airflow-dag-trigger
+    version: 1.0.7
+    repository: https://bcgov.github.io/cas-airflow
+    alias: prod-test-restore

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cas-metabase
 description: A Helm chart for the CAS Metabase instance
 type: application
-version: 0.2.11
+version: 0.2.12
 appVersion: 0.40.3.1
 dependencies:
   - name: cas-postgres

--- a/helm/cas-metabase/values-test.yaml
+++ b/helm/cas-metabase/values-test.yaml
@@ -37,3 +37,11 @@ metabaseHPA:
   enable: true
   minReplicas: 2
   maxReplicas: 5
+
+prod-test-restore:
+  image:
+    tag: 34c1edc251b1ed4f91eef5a39ac4919135af68c9 # pragma: allowlist secret
+  airflowEndpoint: https://cas-airflow-dev.apps.silver.devops.gov.bc.ca
+  dagId: cas_metabase_prod_test_restore
+  helm:
+    hook: "post-install"


### PR DESCRIPTION
add chart dependency so prod-test restore dag downloads & runs on deploy