### PR TITLE
Chore/113 terraform chart

### DIFF
--- a/helm/cas-metabase/Chart.lock
+++ b/helm/cas-metabase/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: cas-postgres
   repository: https://bcgov.github.io/cas-postgres/
-  version: 0.8.4
+  version: 0.9.1
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.0.8
@@ -11,5 +11,8 @@ dependencies:
 - name: certbot
   repository: https://bcdevops.github.io/certbot
   version: 0.1.3
-digest: sha256:b7a0a6774fe89fb6c00d0e5913a4d220542dcbd24b1537ccaf8e69bf5cdae88e
-generated: "2023-03-06T11:53:20.829144245-08:00"
+- name: terraform-bucket-provision
+  repository: https://bcgov.github.io/cas-pipeline/
+  version: 0.1.3
+digest: sha256:fdaafd3137f0ec2851d5bdc0cfcaf44dd8966fe28905ae68ee8404f6d9c13250
+generated: "2024-02-23T12:10:10.736428111-07:00"

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.3.8
 appVersion: 0.46.6.1
 dependencies:
   - name: cas-postgres
-    version: 0.8.4
+    version: 0.9.2
     repository: https://bcgov.github.io/cas-postgres/
   - name: cas-airflow-dag-trigger
     version: 1.0.8

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -20,3 +20,6 @@ dependencies:
   - name: certbot
     version: 0.1.3
     repository: https://bcdevops.github.io/certbot
+  - name: terraform-bucket-provision
+    version: "0.1.3"
+    repository: https://bcgov.github.io/cas-pipeline/

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -6,7 +6,7 @@ version: 0.3.8
 appVersion: 0.46.6.1
 dependencies:
   - name: cas-postgres
-    version: 0.9.2
+    version: 0.9.1
     repository: https://bcgov.github.io/cas-postgres/
   - name: cas-airflow-dag-trigger
     version: 1.0.8

--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -91,3 +91,8 @@ certbot:
     pullPolicy: IfNotPresent
   certbot:
     email: ggircs@gov.bc.ca
+
+terraform-bucket-provision:
+  terraform:
+    namespace_apps: ["mb-backups"]
+    workspace: metabase


### PR DESCRIPTION
Like the other Terraform cloud migrations, this one uses the new `cas-pipeline` `terraform-bucket-provision` chart and updated `cas-postgres` chart (without provisioning). **Unlike** the other migrations, this project deploys into a shared namespace, so uses the workspace functionality value added in bcgov/cas-pipeline#92 to keep its state separate from what `cas-ggircs` holds. 