### PR TITLE
chore: remove certbot from helm deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,6 @@ jobs:
           helm repo add charts-stable https://charts.helm.sh/stable
           helm repo add cas-postgres https://bcgov.github.io/cas-postgres/
           helm repo add cas-airflow https://bcgov.github.io/cas-airflow/
-          helm repo add certbot https://bcdevops.github.io/certbot
           helm repo add pipeline https://bcgov.github.io/cas-pipeline/
 
       - name: Run chart-releaser

--- a/helm/cas-metabase/Chart.lock
+++ b/helm/cas-metabase/Chart.lock
@@ -8,11 +8,8 @@ dependencies:
 - name: cas-airflow-dag-trigger
   repository: https://bcgov.github.io/cas-airflow
   version: 1.0.8
-- name: certbot
-  repository: https://bcdevops.github.io/certbot
-  version: 0.1.3
 - name: terraform-bucket-provision
   repository: https://bcgov.github.io/cas-pipeline/
   version: 0.1.3
-digest: sha256:fdaafd3137f0ec2851d5bdc0cfcaf44dd8966fe28905ae68ee8404f6d9c13250
-generated: "2024-02-23T12:10:10.736428111-07:00"
+digest: sha256:4344c50f074476722ea9a049fbab33053e71ee1c300919132705264a73a6dfba
+generated: "2024-03-11T15:26:40.41001038-07:00"

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -17,9 +17,6 @@ dependencies:
     repository: https://bcgov.github.io/cas-airflow
     alias: prod-test-restore
     condition: prod-test-restore.enable
-  - name: certbot
-    version: 0.1.3
-    repository: https://bcdevops.github.io/certbot
   - name: terraform-bucket-provision
     version: 0.1.3
     repository: https://bcgov.github.io/cas-pipeline/

--- a/helm/cas-metabase/templates/route.yaml
+++ b/helm/cas-metabase/templates/route.yaml
@@ -15,9 +15,6 @@ metadata:
   name: {{ template "cas-metabase.fullname" . }}
   labels:
 {{ include "cas-metabase.labels" . | nindent 4 }}
-    {{- if .Values.route.certbotManaged }}
-    certbot-managed: {{ .Values.route.certbotManaged | quote }}
-    {{- end }}
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
 

--- a/helm/cas-metabase/values-prod.yaml
+++ b/helm/cas-metabase/values-prod.yaml
@@ -21,13 +21,6 @@ cas-postgres:
 route:
   enable: true
   host: cas-metabase.nrs.gov.bc.ca
-  certbotManaged: true
-
-certbot:
-  certbot:
-    server:
-      secretName: cas-acme-url
-      secretKey: url
 
 download-cas-metabase-dags:
   airflowEndpoint: https://cas-airflow-prod.apps.silver.devops.gov.bc.ca

--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -86,12 +86,6 @@ download-cas-metabase-dags:
   helm:
     hook: "pre-install,pre-upgrade"
 
-certbot:
-  image:
-    pullPolicy: IfNotPresent
-  certbot:
-    email: ggircs@gov.bc.ca
-
 terraform-bucket-provision:
   terraform:
     namespace_apps: '["mb-backups"]'


### PR DESCRIPTION
Certbot is no longer supported, removing it from the helm deployment