### PR TITLE
chore: increase/decrease resources based on openshift metrics

### DIFF
--- a/helm/cas-metabase/values-prod.yaml
+++ b/helm/cas-metabase/values-prod.yaml
@@ -3,10 +3,10 @@ cas-postgres:
     resources:
       limits:
         cpu: "1"
-        memory: 2Gi
+        memory: 3Gi
       requests:
         cpu: 15m
-        memory: 600Mi
+        memory: 1300Mi
     walE:
       enable: true
       # the GCS bucket name should be {{ namespace }}-{{ gcs.bucketSuffix }}, has to be < 28 characters

--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -41,10 +41,10 @@ database:
   existingSecretPasswordKey: database-password
 resources:
   limits:
-    cpu: 1
+    cpu: 500m
     memory: 4Gi
   requests:
-    cpu: 250m
+    cpu: 25m
     memory: 2Gi
 podLabels:
   app.kubernetes.io/component: app


### PR DESCRIPTION
Our CPU requests are pretty high for what we're actually using, so those have been dropped significantly. The request levels set for metabase patroni though were low, which may be causing some lag so those have been increased.