### PR TITLE
chore: update metabase from 49 to 52

### DIFF
--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 2
 image:
   repository: metabase/metabase
-  tag: v0.49.6
+  tag: v0.52.4
   pullPolicy: Always
 database:
   type: postgres


### PR DESCRIPTION
Addresses #133. We currently use the Metabase image for v49, latest as of this PR is v52. According to the upgrade docs, [nothing additional is needed](https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase#upgrading-from-older-versions-of-metabase) for this upgrade and there are no breaking changes.

## Changes 🚧

- Base tag for Metabase changed to `0.52.4`
