### PR TITLE
chore: tune metabase and autoscaler

### DIFF
--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cas-metabase
 description: A Helm chart for the CAS Metabase instance
 type: application
-version: 0.4.2
+version: 0.4.3
 appVersion: 0.52.2
 dependencies:
   - name: cas-airflow-dag-trigger

--- a/helm/cas-metabase/templates/autoscaler.yaml
+++ b/helm/cas-metabase/templates/autoscaler.yaml
@@ -10,5 +10,11 @@ spec:
     apiVersion: apps/v1
   minReplicas: {{ .Values.metabaseHPA.minReplicas }}
   maxReplicas: {{ .Values.metabaseHPA.maxReplicas }}
-  targetCPUUtilizationPercentage: 80
+  metrics:
+  - type: Resource
+    resource:
+    name: cpu
+    target:
+      type: Utilization
+      averageUtilization: {{ .Values.metabaseHPA.avgUtilization }}
 {{- end }}

--- a/helm/cas-metabase/values-prod.yaml
+++ b/helm/cas-metabase/values-prod.yaml
@@ -29,3 +29,4 @@ metabaseHPA:
   enable: true
   minReplicas: 2
   maxReplicas: 5
+  avgUtilization: 250

--- a/helm/cas-metabase/values-test.yaml
+++ b/helm/cas-metabase/values-test.yaml
@@ -28,6 +28,7 @@ metabaseHPA:
   enable: true
   minReplicas: 2
   maxReplicas: 5
+  avgUtilization: 250
 
 prod-test-restore:
   enable: false

--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -14,7 +14,7 @@ resources:
     cpu: 500m
     memory: 4Gi
   requests:
-    cpu: 25m
+    cpu: 100m
     memory: 2Gi
 podLabels:
   app.kubernetes.io/component: app


### PR DESCRIPTION
Addresses #132. Changes the autoscaling values to prevent pods going up/down rapidly whenever a user logs in.

## Changes 🚧

- Change `targetCPU` to `metrics`.
- Set Average to percentage over 100 (average is based on `Requests`, not `Limits`).
- Bump up CPU request.