### PR TITLE
chore: bump resources, match recommended for new metabase versions

### DIFF
--- a/helm/cas-metabase/values-prod.yaml
+++ b/helm/cas-metabase/values-prod.yaml
@@ -29,4 +29,4 @@ metabaseHPA:
   enable: true
   minReplicas: 2
   maxReplicas: 5
-  avgUtilization: 250
+  avgUtilization: 350

--- a/helm/cas-metabase/values-test.yaml
+++ b/helm/cas-metabase/values-test.yaml
@@ -28,7 +28,7 @@ metabaseHPA:
   enable: true
   minReplicas: 2
   maxReplicas: 5
-  avgUtilization: 250
+  avgUtilization: 350
 
 prod-test-restore:
   enable: false

--- a/helm/cas-metabase/values.yaml
+++ b/helm/cas-metabase/values.yaml
@@ -11,10 +11,10 @@ database:
   dbname: metabase
 resources:
   limits:
-    cpu: 500m
+    cpu: 3000m
     memory: 4Gi
   requests:
-    cpu: 100m
+    cpu: 1000m
     memory: 2Gi
 podLabels:
   app.kubernetes.io/component: app


### PR DESCRIPTION
Addresses #142. Bumps up resource requests for Metabase pods. Uses recommendations based on [the metabase docs](https://www.metabase.com/learn/metabase-basics/administration/administration-and-operation/metabase-in-production#metabase-application-and-database-servers-and-their-sizing).

## Changes 🚧

- Raise limits and requests for Metabase