### PR TITLE
chore: increase storage size for test/prod pg cluster

### DIFF
--- a/helm/cas-metabase-postgres-cluster/values-prod.yaml
+++ b/helm/cas-metabase-postgres-cluster/values-prod.yaml
@@ -1,1 +1,3 @@
 environment: prod
+postgresCluster:
+  storageSize: 3Gi

--- a/helm/cas-metabase-postgres-cluster/values-test.yaml
+++ b/helm/cas-metabase-postgres-cluster/values-test.yaml
@@ -1,1 +1,3 @@
 environment: test
+postgresCluster:
+  storageSize: 3Gi

--- a/helm/cas-metabase-postgres-cluster/values.yaml
+++ b/helm/cas-metabase-postgres-cluster/values.yaml
@@ -16,6 +16,7 @@ postgresCluster:
     limits:
       cpu: 500m
       memory: 1Gi
+  storageSize: 1Gi
 
   # The "users" value(s) is passed to the crunchy postgres operator to create the database.
   # See https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management


### PR DESCRIPTION
Bumps the PVC storage available to the Postgres cluster in Test and Prod. 