### PR TITLE
Add renovate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /helm/**/charts
 /.deploy/
 .scratch/
+.idea/

--- a/helm/cas-metabase/Chart.yaml
+++ b/helm/cas-metabase/Chart.yaml
@@ -3,4 +3,5 @@ name: cas-metabase
 description: A Helm chart for the CAS Metabase instance
 type: application
 version: 0.9.0
-appVersion: 0.62.3
+# renovate: image=metabase/metabase
+appVersion: v0.62.3

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,36 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  // See: https://github.com/bcgov/renovate-config
+  extends: [
+    "github>bcgov/renovate-config#2026.7.17",
+    // Updates `appVersion` in Chart.yaml by reading the `# renovate: image=...`
+    // comment directly above it. See helm/cas-metabase/Chart.yaml.
+    // https://docs.renovatebot.com/presets-customManagers/#custommanagershelmchartyamlappversions
+    "customManagers:helmChartYamlAppVersions",
+  ],
+
+  //   helm-values    -> helm/cas-metabase/values.yaml  (image.repository + image.tag)
+  //   custom.regex   -> helm/cas-metabase/Chart.yaml   (appVersion)
+  //   github-actions -> .github/workflows/*.yml
+  enabledManagers: ["helm-values", "custom.regex", "github-actions"],
+  labels: ["dependencies"],
+  automerge: false,
+  platformAutomerge: false,
+  dependencyDashboard: false,
+  packageRules: [
+    {
+      // The image is referenced twice and both must move together, otherwise
+      // the chart's appVersion drifts from the image it actually deploys.
+      description: "Metabase — bump values.yaml tag and Chart.yaml appVersion",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["metabase/metabase"],
+      groupName: "metabase",
+
+      // Blocks metabase's -beta tags. Renovate reports isStable:true for them
+      // ("-beta" parses into `suffix`, not `prerelease`), so ignoreUnstable
+      // misses them and a v0.64.0-beta would outrank every stable v0.63.x.
+      allowedVersions: "/^v\\d+\\.\\d+\\.\\d+(\\.\\d+)?$/",
+      minimumReleaseAge: "7 days",
+    },
+  ],
+}


### PR DESCRIPTION
[ISSUE 151](https://github.com/bcgov/cas-metabase/issues/151)

## Summary

Adds Renovate to this repo so the Metabase version is tracked automatically instead of bumped by hand.

Renovate watches the Metabase image in the two places it is pinned and updates **both in a single PR**, so they can't drift:

| File | Field | Manager |
|---|---|---|
| `helm/cas-metabase/values.yaml` | `image.tag` | `helm-values` (built-in) |
| `helm/cas-metabase/Chart.yaml` | `appVersion` | `custom.regex` via `customManagers:helmChartYamlAppVersions` |

GitHub Actions in `.github/workflows/` are also enabled, since several are well behind.

## ⚠️ Required follow-up — this does nothing until the app is installed

Merging this PR only adds config. The **Mend Renovate** GitHub app still has to be enabled on this repo:

1. Go to <https://github.com/bcgov/devops-requests/issues>
2. Click **New issue**
3. Select **`Request to have a Github application added...`**
4. That redirects to Jira — file the request there to have the **Mend Renovate** app added to GitHub for `bcgov/cas-metabase`

Once the app is enabled, Renovate opens an onboarding PR and then begins raising update PRs.

## Validation

```
npx --yes --package renovate -- renovate-config-validator --strict
```